### PR TITLE
Adding freeCodeCamp repository

### DIFF
--- a/firstissue.json
+++ b/firstissue.json
@@ -1298,7 +1298,8 @@
     "zitadel/zitadel",
     "zsh-users/zsh-completions",
     "zsh-users/zsh-syntax-highlighting",
-    "zulip/zulip"
+    "zulip/zulip",
+    "freeCodeCamp/freeCodeCamp"
   ],
   "labels": [
     "good first issue",


### PR DESCRIPTION
"freeCodeCamp/freeCodeCamp" repository (https://github.com/freeCodeCamp/freeCodeCamp). This repository has over 19,000 issues, many of which are labeled with "good first issue" or other labels defined in firstissue.json. It has over 7,000 contributors and over 99,000 stars. The repository includes a detailed README.md file with setup instructions, as well as a CONTRIBUTING.md file with guidelines for new contributors. The repository is actively maintained, with the most recent commit being made within the past month.

#### ℹ️ Repository information

**The repository has**:

- [ ] At least three issues with the `good first issue`, or other labels specified in `firstissue.json` (see `labels` and the end).
 - Link:
- [ ] At least 10 contributors.
- [ ] At least 1000 stars.
- [ ] Detailed setup instructions for the project.
 - Link:
- [ ] CONTRIBUTING.md
- [ ] Actively maintained (last updated less than 1 months ago).
