### PR TITLE
Add freeCodeCamp/freeCodeCamp repository

### DIFF
--- a/firstissue.json
+++ b/firstissue.json
@@ -476,6 +476,7 @@
     "fossas/fossa-cli",
     "fossasia/open-event-server",
     "Foundry376/Mailspring",
+    "freeCodeCamp/freeCodeCamp",
     "freedomofpress/securedrop",
     "FreshRSS/FreshRSS",
     "FStarLang/FStar",


### PR DESCRIPTION
freeCodeCamp repository (https://github.com/freeCodeCamp/freeCodeCamp): This repository has over 19,000 issues, many of which are labeled with "good first issue" or other labels defined in firstissue.json. It has over 7,000 contributors and over 99,000 stars. The repository includes a detailed README.md file with setup instructions, as well as a CONTRIBUTING.md file with guidelines for new contributors. The repository is actively maintained, with the most recent commit being made within the past month.

Link to the issues section: https://github.com/freeCodeCamp/freeCodeCamp/issues

#### ℹ️ Repository information

**The repository has**:

- [ ] At least three issues with the `good first issue`, or other labels specified in `firstissue.json` (see `labels` and the end).
 - Link:
- [ ] At least 10 contributors.
- [ ] At least 1000 stars.
- [ ] Detailed setup instructions for the project.
 - Link:
- [ ] CONTRIBUTING.md
- [ ] Actively maintained (last updated less than 1 months ago).
