### PR TITLE
Fix #25: Reloading on dynamic route page results in 404

### DIFF
--- a/pages/language/[tag].tsx
+++ b/pages/language/[tag].tsx
@@ -13,6 +13,21 @@ export const getStaticPaths: GetStaticPaths = async () => {
     paths: [],
     fallback: true
   };
+
+  /**
+   * The above assumes that this is hosted on some infrastructure
+   * that's capable of SSR, otherwise we'll need to statically generate all possible
+   * language pages at build time
+  
+   ```
+    return {
+      paths: data.languages.map((topic) => ({
+        params: { tag: languages.id }
+      })),
+      fallback: false
+    };
+   ```
+  */
 };
 
 export const getStaticProps: GetStaticProps<LanguageProps> = async ({ params = {} }) => {

--- a/pages/language/[tag].tsx
+++ b/pages/language/[tag].tsx
@@ -1,17 +1,33 @@
+import { GetStaticPaths, GetStaticProps } from "next";
 import Head from "next/head";
-import { useRouter } from "next/router";
 
 import { RepositoryList } from "../../components/RepositoryList";
 import { useAppContext } from "../_app";
 
-export default function Language() {
+type LanguageProps = {
+  tag: string | undefined;
+};
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: [],
+    fallback: true
+  };
+};
+
+export const getStaticProps: GetStaticProps<LanguageProps> = async ({ params = {} }) => {
+  const { tag } = params;
+
+  return {
+    props: { tag: Array.isArray(tag) ? tag[0] : tag }
+  };
+};
+
+export default function Language({ tag }: LanguageProps) {
   const { repositories, languages } = useAppContext();
 
-  const router = useRouter();
-  const { tag } = router.query;
-
-  const language = languages.find((language) => language.id == tag);
-  const pageTitle = `First Issue | ${language?.display} Language`;
+  const language = languages.find((language) => language.id === tag);
+  const pageTitle = `First Issue | ${language?.display ?? ""} Language`;
 
   return (
     <>
@@ -19,7 +35,7 @@ export default function Language() {
         <title>{pageTitle}</title>
       </Head>
       <RepositoryList
-        repositories={repositories.filter((repository) => repository.language.id == tag)}
+        repositories={repositories.filter((repository) => repository.language.id === tag)}
       />
     </>
   );

--- a/pages/language/[tag].tsx
+++ b/pages/language/[tag].tsx
@@ -1,40 +1,33 @@
 import { GetStaticPaths, GetStaticProps } from "next";
 import Head from "next/head";
+import { ParsedUrlQuery } from "querystring";
 
 import { RepositoryList } from "../../components/RepositoryList";
+import data from "../../generated.json";
 import { useAppContext } from "../_app";
 
+interface Params extends ParsedUrlQuery {
+  tag: string;
+}
+
 type LanguageProps = {
-  tag: string | undefined;
+  tag: Params["tag"];
 };
 
-export const getStaticPaths: GetStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths<Params> = async () => {
   return {
-    paths: [],
-    fallback: true
+    paths: data.languages.map((language) => ({
+      params: { tag: language.id }
+    })),
+    fallback: false
   };
-
-  /**
-   * The above assumes that this is hosted on some infrastructure
-   * that's capable of SSR, otherwise we'll need to statically generate all possible
-   * language pages at build time
-  
-   ```
-    return {
-      paths: data.languages.map((topic) => ({
-        params: { tag: languages.id }
-      })),
-      fallback: false
-    };
-   ```
-  */
 };
 
-export const getStaticProps: GetStaticProps<LanguageProps> = async ({ params = {} }) => {
-  const { tag } = params;
-
+export const getStaticProps: GetStaticProps<LanguageProps, Params> = async ({
+  params = {} as Params
+}) => {
   return {
-    props: { tag: Array.isArray(tag) ? tag[0] : tag }
+    props: { tag: params.tag }
   };
 };
 
@@ -42,7 +35,7 @@ export default function Language({ tag }: LanguageProps) {
   const { repositories, languages } = useAppContext();
 
   const language = languages.find((language) => language.id === tag);
-  const pageTitle = `First Issue | ${language?.display ?? ""} Language`;
+  const pageTitle = `First Issue | ${language?.display} Language`;
 
   return (
     <>

--- a/pages/topic/[tag].tsx
+++ b/pages/topic/[tag].tsx
@@ -13,6 +13,21 @@ export const getStaticPaths: GetStaticPaths = async () => {
     paths: [],
     fallback: true
   };
+
+  /**
+   * The above assumes that this is hosted on some infrastructure
+   * that's capable of SSR, otherwise we'll need to statically generate all possible
+   * topic pages at build time
+  
+   ```
+    return {
+      paths: data.topics.map((topic) => ({
+        params: { tag: topic.id }
+      })),
+      fallback: false
+    };
+   ```
+  */
 };
 
 export const getStaticProps: GetStaticProps<TopicProps> = async ({ params = {} }) => {

--- a/pages/topic/[tag].tsx
+++ b/pages/topic/[tag].tsx
@@ -1,40 +1,33 @@
 import { GetStaticPaths, GetStaticProps } from "next";
 import Head from "next/head";
+import { ParsedUrlQuery } from "querystring";
 
 import { RepositoryList } from "../../components/RepositoryList";
+import data from "../../generated.json";
 import { useAppContext } from "../_app";
 
+interface Params extends ParsedUrlQuery {
+  tag: string;
+}
+
 type TopicProps = {
-  tag: string | undefined;
+  tag: Params["tag"];
 };
 
-export const getStaticPaths: GetStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths<Params> = async () => {
   return {
-    paths: [],
-    fallback: true
+    paths: data.topics.map((topic) => ({
+      params: { tag: topic.id }
+    })),
+    fallback: false
   };
-
-  /**
-   * The above assumes that this is hosted on some infrastructure
-   * that's capable of SSR, otherwise we'll need to statically generate all possible
-   * topic pages at build time
-  
-   ```
-    return {
-      paths: data.topics.map((topic) => ({
-        params: { tag: topic.id }
-      })),
-      fallback: false
-    };
-   ```
-  */
 };
 
-export const getStaticProps: GetStaticProps<TopicProps> = async ({ params = {} }) => {
-  const { tag } = params;
-
+export const getStaticProps: GetStaticProps<TopicProps, Params> = async ({
+  params = {} as Params
+}) => {
   return {
-    props: { tag: Array.isArray(tag) ? tag[0] : tag }
+    props: { tag: params.tag }
   };
 };
 
@@ -42,7 +35,7 @@ export default function Topic({ tag }: TopicProps) {
   const { repositories, topics } = useAppContext();
 
   const topic = topics.find((topic) => topic.id === tag);
-  const pageTitle = `First Issue | Topic ${topic?.display ?? ""}`;
+  const pageTitle = `First Issue | Topic ${topic?.display}`;
 
   return (
     <>

--- a/pages/topic/[tag].tsx
+++ b/pages/topic/[tag].tsx
@@ -1,28 +1,25 @@
 import { GetStaticPaths, GetStaticProps } from "next";
 import Head from "next/head";
-import { ParsedUrlQuery } from "querystring";
 
 import { RepositoryList } from "../../components/RepositoryList";
 import { useAppContext } from "../_app";
 
-interface Params extends ParsedUrlQuery {
-  tag: string | undefined;
-}
-
 type TopicProps = {
-  tag: Params["tag"];
+  tag: string | undefined;
 };
 
-export const getStaticPaths: GetStaticPaths<Params> = async () => {
+export const getStaticPaths: GetStaticPaths = async () => {
   return {
     paths: [],
     fallback: true
   };
 };
 
-export const getStaticProps: GetStaticProps<TopicProps, Params> = async ({ params = {} }) => {
+export const getStaticProps: GetStaticProps<TopicProps> = async ({ params = {} }) => {
+  const { tag } = params;
+
   return {
-    props: { tag: params.tag }
+    props: { tag: Array.isArray(tag) ? tag[0] : tag }
   };
 };
 

--- a/pages/topic/[tag].tsx
+++ b/pages/topic/[tag].tsx
@@ -1,17 +1,36 @@
+import { GetStaticPaths, GetStaticProps } from "next";
 import Head from "next/head";
-import { useRouter } from "next/router";
+import { ParsedUrlQuery } from "querystring";
 
 import { RepositoryList } from "../../components/RepositoryList";
 import { useAppContext } from "../_app";
 
-export default function Topic() {
+interface Params extends ParsedUrlQuery {
+  tag: string | undefined;
+}
+
+type TopicProps = {
+  tag: Params["tag"];
+};
+
+export const getStaticPaths: GetStaticPaths<Params> = async () => {
+  return {
+    paths: [],
+    fallback: true
+  };
+};
+
+export const getStaticProps: GetStaticProps<TopicProps, Params> = async ({ params = {} }) => {
+  return {
+    props: { tag: params.tag }
+  };
+};
+
+export default function Topic({ tag }: TopicProps) {
   const { repositories, topics } = useAppContext();
 
-  const router = useRouter();
-  const { tag } = router.query;
-
-  const topic = topics.find((topic) => topic.id == tag);
-  const pageTitle = `First Issue | Topic ${topic?.display}`;
+  const topic = topics.find((topic) => topic.id === tag);
+  const pageTitle = `First Issue | Topic ${topic?.display ?? ""}`;
 
   return (
     <>
@@ -20,7 +39,7 @@ export default function Topic() {
       </Head>
       <RepositoryList
         repositories={repositories.filter((repository) =>
-          repository.topics?.some((topic) => topic.id == tag)
+          repository.topics?.some((topic) => topic.id === tag)
         )}
       />
     </>


### PR DESCRIPTION
## Overview

This PR fixes #25

Since we run `next export` and serve the resulting static files on github pages, we'll need to statically generate all possible language/topic pages at build time since SSR is not supported

Something to note: at the time of writing this PR, the site current has `489` distinct topics and based on the latest Octoverse 2022 report, github supports `~500` distinct programming languages. [NextJS recommends](https://nextjs.org/docs/api-reference/data-fetching/get-static-paths#when-is-fallback-true-useful) that if you need to pre-render hundreds/thousands of pages, we should lazily render the dynamic pages via SSR by setting `fallback: true` so that build times aren't negatively impacted from needing to pre-render hundreds of pages--but since SSR is not supported this is the only viable alternative (that I could think of anyway lol)

I assume that since the data is already available at build time, it shouldn't negatively impact build times by _that_ much 🤔 

## Testing

Running `npm run build` results in generation of multiple languages/topic pages

```bash
Route (pages)                              Size     First Load JS
┌ ○ /                                      1.75 kB         127 kB
├   /_app                                  0 B             119 kB
├ ○ /404                                   226 B           119 kB
├ ● /language/[tag]                        1.8 kB          127 kB
├   ├ /language/go
├   ├ /language/java
├   ├ /language/javascript
├   └ /language/python
├ ○ /search/[tag]                          1.91 kB         127 kB
└ ● /topic/[tag] (1128 ms)                 1.83 kB         127 kB
    ├ /topic/kubernetes
    ├ /topic/hacktoberfest
    ├ /topic/docker
    └ [+6 more paths]
+ First Load JS shared by all              130 kB
  ├ chunks/framework-46611630e39cfdeb.js   45.3 kB
  ├ chunks/main-3b682fddce25bb14.js        27 kB
  ├ chunks/pages/_app-f6f3f1542b458c92.js  45.5 kB
  ├ chunks/webpack-84a7614cbb05aa5f.js     801 B
  └ css/081265f18bfb5e27.css               11 kB
```

Reloading the page + manually inputting a dynamic route in the url path yields the expected result (after exporting static files via `npm run export` and serving via `npx serve`)

https://user-images.githubusercontent.com/23093814/233871613-9a25fb0f-4cfa-417e-812f-9f1d8425442e.mov
