### PR TITLE
Fix #32 Create Button order by start and date

### DIFF
--- a/components/RepositoryList.tsx
+++ b/components/RepositoryList.tsx
@@ -8,6 +8,8 @@ import { RepositoryItem } from "./RepositoryItem";
 
 type RepositoryListProps = {
   repositories: Repository[];
+  dtOrder: boolean;
+  starOrder: boolean;
 };
 
 const Loader = () => (
@@ -18,9 +20,48 @@ const Loader = () => (
   </div>
 );
 
-export const RepositoryList = ({ repositories }: RepositoryListProps) => {
+export const RepositoryList = ({ repositories, dtOrder, starOrder  }: RepositoryListProps) => {
   const itemsPerScroll = 15;
   const [items, setItems] = useState(itemsPerScroll);
+
+  if (dtOrder){
+    repositories.sort(function (a, b) {
+      if (a.last_modified < b.last_modified) {
+        return 1;
+      }
+      if (a.last_modified > b.last_modified) {
+        return -1;
+      }
+      return 0;
+    });
+  }
+  
+  if(dtOrder){
+    //ordenando as Issues
+    repositories.map ((repository)=>{
+      repository.issues.sort(function (a, b) {
+        if (a.created_at < b.created_at) {
+          return 1;
+        }
+        if (a.created_at > b.created_at) {
+          return -1;
+        }
+        return 0;
+      });
+    })
+  }
+
+  if (starOrder){
+    repositories.sort(function (a, b) {
+      if (a.stars < b.stars) {
+        return 1;
+      }
+      if (a.stars > b.stars) {
+        return -1;
+      }
+      return 0;
+    });
+  }
 
   return (
     <main>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -6,6 +6,7 @@ import { AddYourProjectLinkButton } from "./AddYourProjectLinkButton";
 import { SidebarAboutSection } from "./SidebarAboutSection";
 import { SidebarLanguagePicker } from "./SidebarLanguagePicker";
 import { SidebarTopicPicker } from "./SidebarTopicPicker";
+import { SidebarOrder } from "./SidebarOrder";
 
 const DEFAULT_TOPICS_LIMIT = 15;
 
@@ -28,6 +29,7 @@ export const Sidebar = () => {
   return (
     <section className="font-sans pt-6 px-6 text-vanilla-300 flex-none w-full md:max-w-sm">
       <SidebarAboutSection />
+      <SidebarOrder />
       <SidebarLanguagePicker languages={languages} activeTagId={activeTagId} pageName={pageName} />
       <SidebarTopicPicker
         activeTagId={activeTagId}

--- a/components/SidebarOrder.tsx
+++ b/components/SidebarOrder.tsx
@@ -1,0 +1,67 @@
+import { faHeart } from "@fortawesome/free-regular-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import React from "react";
+
+import data from "../order.json";
+
+const ByLine = () => (
+  <div className="text-sm pt-6">
+    <h3 className="text-sm font-bold uppercase tracking-wider mb-2 text-slate">Sort By</h3>
+  </div>
+);
+
+
+export const SidebarOrder = () => {
+    const [dtOrder, setDtOrder] = React.useState(false);
+    const [starOrder, setStarOrder] = React.useState(false);
+
+    const changeDtOrder =()=>{
+        if (dtOrder === true){
+          setDtOrder(false) ;
+          data.date = false;
+    
+        }else{
+          setDtOrder(true) ;
+          setStarOrder(false);
+          data.date = true;
+          data.star = false;
+        }
+      }
+    
+      const changeStarOrder =()=>{
+        if (starOrder === true){
+          setStarOrder(false) ;
+          data.star = false;
+    
+        }else{
+          setStarOrder(true) ;
+          setDtOrder(false);
+          data.star = true;
+          data.date = false;
+        }
+      }
+    
+  return (
+    <div>
+        <ByLine />
+        <div >
+          {data.date === true && (
+            <button  style={{ border: '1px solid #555'}} className="true" onClick={changeDtOrder}  > Order Date</button>
+          )}
+           {data.date === false && (
+            <button className="false" onClick={changeDtOrder}  > Order Date</button>
+          )}          
+        </div>
+        <br />
+        <div>
+          {data.star === true &&(
+            <button style={{ border: '1px solid #555'}} className="true" onClick={changeStarOrder} > Order Star </button>
+          )}
+          {data.star === false &&(
+            <button className="false" onClick={changeStarOrder} > Order Star </button>
+          )}
+        </div>
+      
+    </div>
+  );
+};

--- a/order.json
+++ b/order.json
@@ -1,0 +1,4 @@
+{
+    "date": false,
+    "star": false
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,6 +3,8 @@ import Head from "next/head";
 import { RepositoryList } from "../components/RepositoryList";
 import { useAppContext } from "./_app";
 
+import data from "../order.json";
+
 export default function Home() {
   const { repositories } = useAppContext();
 
@@ -11,7 +13,7 @@ export default function Home() {
       <Head>
         <title>First Issue | Issues for your next open-source contribution</title>
       </Head>
-      <RepositoryList repositories={repositories} />
+      <RepositoryList repositories={repositories} dtOrder={data.date} starOrder={data.star}/>
     </>
   );
 }

--- a/pages/language/[tag].tsx
+++ b/pages/language/[tag].tsx
@@ -4,6 +4,8 @@ import { useRouter } from "next/router";
 import { RepositoryList } from "../../components/RepositoryList";
 import { useAppContext } from "../_app";
 
+import data from "../../order.json";
+
 export default function Language() {
   const { repositories, languages } = useAppContext();
 
@@ -19,7 +21,7 @@ export default function Language() {
         <title>{pageTitle}</title>
       </Head>
       <RepositoryList
-        repositories={repositories.filter((repository) => repository.language.id == tag)}
+        repositories={repositories.filter((repository) => repository.language.id == tag)} dtOrder={data.date} starOrder={data.star}
       />
     </>
   );

--- a/pages/search/[tag].tsx
+++ b/pages/search/[tag].tsx
@@ -5,6 +5,8 @@ import { RepositoryList } from "../../components/RepositoryList";
 import { CountableTag } from "../../types";
 import { useAppContext } from "../_app";
 
+import data from "../../order.json";
+
 export default function Language() {
   const { repositories, languages, topics } = useAppContext();
 
@@ -34,7 +36,7 @@ export default function Language() {
       <Head>
         <title>{pageTitle}</title>
       </Head>
-      <RepositoryList repositories={queriedRepositories} />
+      <RepositoryList repositories={queriedRepositories} dtOrder={data.date} starOrder={data.star}/>
       {queriedLanguages}
       {queriedTopics}
     </>

--- a/pages/topic/[tag].tsx
+++ b/pages/topic/[tag].tsx
@@ -4,6 +4,8 @@ import { useRouter } from "next/router";
 import { RepositoryList } from "../../components/RepositoryList";
 import { useAppContext } from "../_app";
 
+import data from "../../order.json";
+
 export default function Topic() {
   const { repositories, topics } = useAppContext();
 
@@ -21,7 +23,7 @@ export default function Topic() {
       <RepositoryList
         repositories={repositories.filter((repository) =>
           repository.topics?.some((topic) => topic.id == tag)
-        )}
+        )} dtOrder={data.date} starOrder={data.star}
       />
     </>
   );


### PR DESCRIPTION
Issue https://github.com/lucavallin/first-issue/issues/32

Changed Files:

1. first-issue\pages\language[tag].tsx
2. first-issue\pages\topic[tag].tsx
3. first-issue\pages\search[tag].tsx
4. first-issue\pages\index.tsx
5. first-issue\components\Sidebar.tsx
6. first-issue\components\RepositoryList.tsx

Create Files:

1. first-issue\components\SidebarOrder.tsx
2. first-issue\order.json

Verification
1. npm install
2. npm run dev
3. On the main screen, choose which button you want to sort by date or star.
4. Select the desired option and then add the word First Issue to reload the page with that button.

