### PR TITLE
fix/duplicate results from the sorting 

### DIFF
--- a/components/RepositoryList.tsx
+++ b/components/RepositoryList.tsx
@@ -31,9 +31,11 @@ export const RepositoryList = ({ repositories }: RepositoryListProps) => {
           hasMore={items < repositories.length}
           loader={<Loader />}
         >
-          {repositories.slice(0, items).map((repository) => (
-            <RepositoryItem key={repository.id} repository={repository} />
-          ))}
+          {repositories.slice(0, items).map((repository) => {
+            //NOTE - We sometimes get duplicate values back from GitHub API
+            // meaning we can't simply rely on the id as the key
+            return <RepositoryItem key={repository.id + Math.random()} repository={repository} />;
+          })}
         </InfiniteScroll>
       </div>
     </main>


### PR DESCRIPTION
### Changes

- Fixes a bug wherein the results of the sorted array were duplicating
  - In Investigating it became clear that the GitHub API would return duplicates (i.e. the same repo twice)
  - And we were using the id as a key when slicing, and then mapping over the results
  - The solution then, is to attempt to make the key more unique (i.e. append to the id a `Math.random()`)
  - That fixes the issue

#### ℹ️ Repository information

**The repository has**:

- [ ] At least three issues with the `good first issue`, or other labels specified in `firstissue.json` (see `labels` and the end).
 - Link:
- [ ] At least 10 contributors.
- [ ] At least 1000 stars.
- [ ] Detailed setup instructions for the project.
 - Link:
- [ ] CONTRIBUTING.md
- [ ] Actively maintained (last updated less than 1 months ago).
