### PR TITLE
Fix duplicate issues in repositories

### DIFF
--- a/generate.ts
+++ b/generate.ts
@@ -91,7 +91,7 @@ const issueLimit = 10;
 
     // Promise<any> is a hack to get around the very complicated type of octokit.issues.listForRepo
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const issuesData = await firstissue.labels.reduce<Promise<any>>(
+    const issues: any[] = await firstissue.labels.reduce<Promise<any>>(
       async (issuesList, label: string) => {
         const { data } = await octokit.issues.listForRepo({
           owner,
@@ -106,6 +106,10 @@ const issueLimit = 10;
       },
       Promise.resolve([])
     );
+
+    // Duplicates may occur when issues have multiple desired labels
+    // Remove duplicates in the issues array
+    const issuesData = [...new Map(issues.map(issue => [issue.id, issue])).values()];
 
     // Skip repos that have no issues with the labels we want
     if (issuesData.length == 0) return repositoryList;


### PR DESCRIPTION
Fixes #133

### Changes
- Remove duplicate issues after getting issues for a repository.

### Comments
This issue occurs when there are multiple labels defined in `firstissue.json`. Since we make a request for each label, issues that have more than one of these labels will appear multiple times.

I tried setting all the labels we want in the `labels` property of `octokit.issues.listForRepo`, but doing so will return only issues that have ALL the labels, as opposed to returning issues that have at least one of the labels. Seems like all we can do for now is to remove the duplicates after making the requests.

Anyways, here are some before and after screenshots :
<details><summary>Before</summary>
<p>

_Note: removed the issue limit to better illustrate the fix_
![image](https://github.com/lucavallin/first-issue/assets/138202184/98fc936b-69aa-4e06-ade8-8c7b6bb203f2)

</p>
</details> 

<details><summary>After</summary>
<p>

_Note: removed the issue limit to better illustrate the fix_
![image](https://github.com/lucavallin/first-issue/assets/138202184/ae046f46-c26b-4ebd-87c6-25184f6f82f4)

</p>
</details> 
   
