### PR TITLE
Let repository list take up full width

### DIFF
--- a/components/RepositoryList.tsx
+++ b/components/RepositoryList.tsx
@@ -23,7 +23,7 @@ export const RepositoryList = ({ repositories }: RepositoryListProps) => {
   const [items, setItems] = useState(itemsPerScroll);
 
   return (
-    <main>
+    <main className="grow">
       <div className="p-4 w-full">
         <InfiniteScroll
           dataLength={items}


### PR DESCRIPTION
PR to close #141

### **Changes**
- Add `grow` class to repo container

### **Comment**
I think adding a single class is the easiest way to fix this. Another option could be to use grid instead and have two columns, one for filters and one for repositories. I don't think that is necessary though.