### PR TITLE
Fix Mattermost repository URL

### DIFF
--- a/firstissue.json
+++ b/firstissue.json
@@ -754,7 +754,7 @@
     "masoniteframework/masonite",
     "MaterialDesignInXAML/MaterialDesignInXamlToolkit",
     "matplotlib/matplotlib",
-    "mattermost/mattermost-server",
+    "mattermost/mattermost",
     "mattgodbolt/compiler-explorer",
     "mautic/mautic",
     "mavoweb/mavo",


### PR DESCRIPTION
This PR updates the repository name to reflect the [new Mattermost monorepo](https://github.com/mattermost/mattermost) which includes `mattermost-server`. It seems that the build process for `first-issue` does not follow repository redirects, so Mattermost is currently hidden from the list.

#### ℹ️ Repository information

**The repository has**:

- [x] At least three issues with the `good first issue`, or other labels specified in `firstissue.json` (see `labels` and the end).
 - Link: https://github.com/mattermost/mattermost/issues?q=is%3Aissue+is%3Aopen+label%3A%22Good+First+Issue%22
- [x] At least 10 contributors.
- [x] At least 1000 stars.
- [x] Detailed setup instructions for the project.
 - Link: https://github.com/mattermost/mattermost?tab=readme-ov-file#install-mattermost
- [x] CONTRIBUTING.md
- [x] Actively maintained (last updated less than 1 months ago).
