### PR TITLE
[UI]: added extra spaces and color to UI

### DIFF
--- a/components/IssueItem.tsx
+++ b/components/IssueItem.tsx
@@ -22,11 +22,11 @@ const IssueCommentNum = ({ numIssues }: IssueCommentNumProps) => {
 
 export const IssueItem = ({ issue }: IssueItemProps) => {
   return (
-    <li key={issue.url} className="flex flex-row items-start justify-start py-1">
+    <li key={issue.url} className="flex flex-row items-start justify-start py-1 gap-5 my-3">
       <span className="text-slate text-right w-30 px-2 leading-snug">#{issue.number}</span>
-      <div className="flex items-start flex-row flex-auto">
+      <div className="flex items-start flex-row flex-auto gap-3">
         <a
-          className="break-all mr-4 leading-snug hover:text-juniper block flex-auto"
+          className="mr-4 leading-snug hover:text-juniper block flex-auto"
           href={issue.url}
           rel="noopener noreferrer"
           target="_blank"

--- a/components/RepositoryMetadata.tsx
+++ b/components/RepositoryMetadata.tsx
@@ -17,7 +17,7 @@ export const RepositoryMetadata = ({
     <div
       className={`flex-row flex text-sm py-1 font-mono ${isIssueOpen ? "font-bold" : "font-light"}`}
     >
-      <div className="mr-4">
+      <div className={`mr-4 ${isIssueOpen ? "bg-vanilla-200 text-[black] px-2 rounded-lg" : ""}`}>
         <span className="text-green-600">lang: </span>
         {repositoryLang}
       </div>


### PR DESCRIPTION
### Issue #188 

Improves UI of repository items by adding some extra margin vertically and some gap between issue URL and issue title. Also, I have added extra color to lang variable if the issue if opened.

Screenshots:
Before:
![image](https://github.com/lucavallin/first-issue/assets/59719358/0b93f773-1e12-4485-a62a-f1be47a6cae0)

After:
![image](https://github.com/lucavallin/first-issue/assets/59719358/eeacc27b-44e0-455e-b79b-fa783ee3364c)


