### PR TITLE
Fix : Mobile view navigation improvements

### DIFF
--- a/components/NewsletterSection.tsx
+++ b/components/NewsletterSection.tsx
@@ -18,7 +18,7 @@ export const NewsletterSection = () => {
   });
 
   return (
-    <div className="pt-6 hidden md:block">
+    <div className="pt-6">
       <SectionTitle text="Join the Newsletter" />
       <p className="text-sm">
         Join the FirstIssue.dev newsletter and receive curated issues in your inbox every week.

--- a/components/NewsletterSection.tsx
+++ b/components/NewsletterSection.tsx
@@ -18,7 +18,7 @@ export const NewsletterSection = () => {
   });
 
   return (
-    <div className="pt-6">
+    <div className="pt-6 hidden md:block">
       <SectionTitle text="Join the Newsletter" />
       <p className="text-sm">
         Join the FirstIssue.dev newsletter and receive curated issues in your inbox every week.

--- a/components/Picker/LanguagePicker.tsx
+++ b/components/Picker/LanguagePicker.tsx
@@ -29,7 +29,7 @@ export const LanguagePicker = ({ activeTagId, languages, onLanguagePage }: Langu
           icon={faChevronDown}
           className={`mx-2 mt-[3px] transform text-secondary transition-transform ${
             isCollapsed ? "rotate-0" : "rotate-180"
-          } animate-fade-in duration-300 ease-in-out lg:hidden`}
+          } animate-fade-in duration-300 ease-in-out md:hidden`}
         />
       </div>
       <div

--- a/components/Picker/LanguagePicker.tsx
+++ b/components/Picker/LanguagePicker.tsx
@@ -1,3 +1,6 @@
+import { faChevronDown } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useState } from "react";
 import { CountableTag } from "../../types";
 import { SectionTitle } from "../SectionTitle";
 import { PickerItem } from "./PickerItem";
@@ -9,17 +12,38 @@ type LanguagePickerProps = {
 };
 
 export const LanguagePicker = ({ activeTagId, languages, onLanguagePage }: LanguagePickerProps) => {
+  const [isCollapsed, setIsCollapsed] = useState<boolean>(true);
+
+  const toggleCollapsible = () => {
+    setIsCollapsed(!isCollapsed);
+  };
+
   return (
     <div className="pt-6">
-      <SectionTitle text="Browse by Language" />
-      <div>
+      <div
+        onClick={toggleCollapsible}
+        className={`flex cursor-pointer ${isCollapsed ? "sm:flex" : ""}`}
+      >
+        <SectionTitle text="Browse by Language" />
+        <FontAwesomeIcon
+          icon={faChevronDown}
+          className={`mx-2 mt-[3px] transform text-secondary transition-transform ${
+            isCollapsed ? "rotate-0" : "rotate-180"
+          } animate-fade-in duration-300 ease-in-out lg:hidden`}
+        />
+      </div>
+      <div
+        className={`transition-max-height overflow-hidden duration-300 ease-in-out ${
+          isCollapsed ? "max-h-0" : "max-h-96"
+        } ${isCollapsed ? "sm:max-h-full" : ""}`}
+      >
         {languages.map((language) => {
           return (
             <PickerItem
               className={`group mx-1 my-1 inline-block rounded-sm border px-2 py-1 text-sm ${
                 onLanguagePage && language.id === activeTagId
                   ? "active-pill"
-                  : "border-secondary transition-all transition-all hover:border-primary hover:text-primary"
+                  : "border-secondary transition-all hover:border-primary hover:text-primary"
               }`}
               href={`/language/${language.id}`}
               key={language.id}

--- a/components/Picker/SortPicker.tsx
+++ b/components/Picker/SortPicker.tsx
@@ -9,7 +9,7 @@ type SortPickerProps = {
 
 export const SortPicker = ({ activeSort, sortOptions, onSortOrderSelect }: SortPickerProps) => {
   return (
-    <div className="flex flex-col justify-between pt-6 md:flex-row md:items-center md:pt-0">
+    <div className="flex flex-col justify-between pt-6 md:flex-row md:items-center md:pt-0" id="repositories-list">
       <div>
         <SectionTitle text="Sort Repositories" />
       </div>
@@ -22,7 +22,7 @@ export const SortPicker = ({ activeSort, sortOptions, onSortOrderSelect }: SortP
               className={`group mx-1 my-1 inline-block rounded-sm border px-2 py-1 text-sm ${
                 activeSort === sortOption
                   ? "active-pill"
-                  : "border-secondary transition-all transition-all hover:border-primary hover:text-primary"
+                  : "border-secondary transition-all hover:border-primary hover:text-primary"
               }`}
             >
               {sortOption}

--- a/components/Picker/TagPicker.tsx
+++ b/components/Picker/TagPicker.tsx
@@ -46,7 +46,7 @@ export const TagPicker = ({ tags, activeTagId, onTagPage }: TagPickerProps) => {
           icon={faChevronDown}
           className={`mx-2 mt-[3px] transform text-secondary transition-transform ${
             isCollapsed ? "rotate-0" : "rotate-180"
-          } animate-fade-in duration-300 ease-in-out lg:hidden`}
+          } animate-fade-in duration-300 ease-in-out md:hidden`}
         />
       </div>
       <div

--- a/components/Picker/TagPicker.tsx
+++ b/components/Picker/TagPicker.tsx
@@ -1,5 +1,6 @@
+import { faChevronDown } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useState } from "react";
-
 import { CountableTag } from "../../types";
 import { ShowMoreButton } from "../Button/ShowMoreButton";
 import { SectionTitle } from "../SectionTitle";
@@ -17,6 +18,12 @@ export const TagPicker = ({ tags, activeTagId, onTagPage }: TagPickerProps) => {
   const [limit, setLimit] = useState(limitStep);
   const hasMore = tags.length > limit;
 
+  const [isCollapsed, setIsCollapsed] = useState<boolean>(true);
+
+  const toggleCollapsible = () => {
+    setIsCollapsed(!isCollapsed);
+  };
+
   const handleShowMore = () => {
     if (!hasMore) {
       setLimit(15);
@@ -30,15 +37,30 @@ export const TagPicker = ({ tags, activeTagId, onTagPage }: TagPickerProps) => {
 
   return (
     <div className="pt-6">
-      <SectionTitle text="Browse by tag" />
-      <div>
+      <div
+        onClick={toggleCollapsible}
+        className={`flex cursor-pointer ${isCollapsed ? "sm:flex" : ""}`}
+      >
+        <SectionTitle text="Browse by tag" />
+        <FontAwesomeIcon
+          icon={faChevronDown}
+          className={`mx-2 mt-[3px] transform text-secondary transition-transform ${
+            isCollapsed ? "rotate-0" : "rotate-180"
+          } animate-fade-in duration-300 ease-in-out lg:hidden`}
+        />
+      </div>
+      <div
+        className={`transition-max-height overflow-hidden duration-300 ease-in-out ${
+          isCollapsed ? "max-h-0" : "max-h-96"
+        } ${isCollapsed ? "sm:max-h-full" : ""}`}
+      >
         {tags.slice(0, limit).map((tag) => {
           return (
             <PickerItem
               className={`group mx-1 my-1 inline-block rounded-sm border px-2 py-1 text-sm ${
                 onTagPage && tag.id === activeTagId
                   ? "active-pill"
-                  : "border-secondary transition-all transition-all hover:border-primary hover:text-primary"
+                  : "border-secondary transition-all hover:border-primary hover:text-primary"
               }`}
               href={`/tag/${tag.id}`}
               key={tag.id}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -8,23 +8,21 @@ import { LinkButton } from "./Button/LinkButton";
 import { NewsletterSection } from "./NewsletterSection";
 import { LanguagePicker } from "./Picker/LanguagePicker";
 import { TagPicker } from "./Picker/TagPicker";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 export const Sidebar = () => {
   const router = useRouter();
   const { languages, tags } = useAppData();
   const { tag: activeTagId } = router.query;
   const pageName = router.pathname.split("/")[1];
-  const [isMobileView, setIsMobileView] = useState(false);
   
   useEffect(() => {
     const scrollTarget = document.getElementById("repositories-list");
     const isMobile = window.innerWidth <= 640; 
-    setIsMobileView(isMobile);
     if (isMobile && (pageName === "language" || pageName === "tag")) {
       scrollTarget?.scrollIntoView({ behavior: "smooth" });
     }
-  }, [router.asPath]);
+  }, [router.asPath, pageName]);
 
   return (
     <section className="w-full flex-none px-6 font-sans text-light-300 md:max-w-sm">

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -8,12 +8,23 @@ import { LinkButton } from "./Button/LinkButton";
 import { NewsletterSection } from "./NewsletterSection";
 import { LanguagePicker } from "./Picker/LanguagePicker";
 import { TagPicker } from "./Picker/TagPicker";
+import { useEffect, useState } from "react";
 
 export const Sidebar = () => {
   const router = useRouter();
   const { languages, tags } = useAppData();
   const { tag: activeTagId } = router.query;
   const pageName = router.pathname.split("/")[1];
+  const [isMobileView, setIsMobileView] = useState(false);
+  
+  useEffect(() => {
+    const scrollTarget = document.getElementById("repositories-list");
+    const isMobile = window.innerWidth <= 640; 
+    setIsMobileView(isMobile);
+    if (isMobile && (pageName === "language" || pageName === "tag")) {
+      scrollTarget?.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [router.asPath]);
 
   return (
     <section className="w-full flex-none px-6 font-sans text-light-300 md:max-w-sm">


### PR DESCRIPTION
### Fixes issue: #194 

### Description:
This pull request solves the following issues:
- In mobile view, the languages and tags picker section is collapsible
- In mobile view, when a language or tag is clicked it automatically scrolls down to the repositories list section

### Screenshots:

[Mobile View Improvement.webm](https://github.com/lucavallin/first-issue/assets/72064600/7c156e3b-be97-4715-8864-e5aaa89b2739)


