### PR TITLE
[FIX - #216] Fixed RepositoryIsssueNumberIndicator CSS

### DIFF
--- a/components/Repository/RepositoryIssueNumberIndicator.tsx
+++ b/components/Repository/RepositoryIssueNumberIndicator.tsx
@@ -9,9 +9,8 @@ export const RepositoryIssueNumberIndicator = ({
 }: RepositoryIssueNumberIndicatorProps) => {
   return (
     <span
-      className={`ml-2 hidden rounded-full border px-3 py-1 text-sm font-semibold md:inline ${
-        isIssueOpen ? "border-transparent bg-primary text-dark-400" : "text-light-200"
-      }`}
+      className={`ml-2 hidden rounded-full border min-w-fit h-fit p-2 text-sm font-semibold md:inline ${isIssueOpen ? "border-transparent bg-primary text-dark-400" : "text-light-200"
+        }`}
     >
       {numberOfIssues}
       {numberOfIssues >= 10 ? "+" : ""} issue


### PR DESCRIPTION
This PR fixes issue #216 

# The Problem


The [RepositoryIssueNumberIndicatior](https://github.com/lucavallin/first-issue/blob/eee0dd4e54c0d0cee10962f1b81eeabfa4be5869/components/Repository/RepositoryIssueNumberIndicator.tsx#L6) component had an inconsistent design which was breaking for viewports lesser than ~1000px. See below:

https://github.com/lucavallin/first-issue/assets/88842947/b8cb32a6-71f7-4439-8e81-307dc94ad03a


As you can see, the issue number component's CSS breaks at around 1000px. The it stays broken until ~750px then after that the component hides (default behaviour).

Verified this issue in:
- Latest Chrome.
- Latest Firefox.

# The Solution
I changed the component's CSS styles and it is fixed now. See below:


https://github.com/lucavallin/first-issue/assets/88842947/1906c675-c66d-41c3-b1b2-cfb2c95d1e76

# After Merging ✨
If this PR gets merged ✨, please added the label `hacktoberfest-accepted` to it. It is necessary for the PR to have this label as per the guidelines of Hacktoberfest.