### PR TITLE
Issue #227: Automatic Sidebar Collapse on Navigation Enhancement

### DIFF
--- a/components/Picker/LanguagePicker.tsx
+++ b/components/Picker/LanguagePicker.tsx
@@ -1,6 +1,6 @@
 import { faChevronDown } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { CountableTag } from "../../types";
 import { SectionTitle } from "../SectionTitle";
 import { PickerItem } from "./PickerItem";
@@ -17,6 +17,11 @@ export const LanguagePicker = ({ activeTagId, languages, onLanguagePage }: Langu
   const toggleCollapsible = () => {
     setIsCollapsed(!isCollapsed);
   };
+
+  // Use useEffect to automatically collapse the sidebar after redirection
+  useEffect(() => {
+    setIsCollapsed(true);
+  }, [activeTagId, onLanguagePage]);
 
   return (
     <div className="pt-6">


### PR DESCRIPTION
### What dose this PR do?

Fixes #227 

This pull request addresses a usability issue in our web by implementing automatic sidebar collapse upon user navigation to different pages. The original behavior, which kept the sidebar expanded even after navigating to a new page, posed several challenges, especially on smaller screens.


https://github.com/lucavallin/first-issue/assets/79717215/0a9d78fc-1249-4e96-97da-0c06fcffa965

