### PR TITLE
fix(BuyMeCoffee content): iframe min-height and max-height overwritten for height issue and fixes #268

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -28,3 +28,9 @@
 .active-pill > span {
   @apply text-primary;
 }
+
+#bmc-iframe {
+  min-height: 750px !important;
+  max-height: 750px !important;
+}
+


### PR DESCRIPTION
## General improvements for Issue [#268 ](https://github.com/lucavallin/first-issue/issues/268)

This PR consist of  UI design fixes that improve the repository design. The change is:
- [x]  Changed iFrame height of the buyMeCoffee that improve the design.

After changing the UI looks like:
![image](https://github.com/lucavallin/first-issue/assets/74503611/8b601c17-840c-4033-862c-2b75f0d6bac2)

